### PR TITLE
Close #41: Dock Badge and Notifications Check

### DIFF
--- a/Cirruscope.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cirruscope.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/i2h3/rainmaker",
       "state" : {
-        "revision" : "598b7d367c0214651b300a81ec1cd6bce1d31d4e",
-        "version" : "3.2.0"
+        "revision" : "972434b3258453512919205935d8d2846d61a539",
+        "version" : "3.3.0"
       }
     },
     {

--- a/Cirruscope/AppDelegate/AppDelegate.swift
+++ b/Cirruscope/AppDelegate/AppDelegate.swift
@@ -39,8 +39,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         UserNotifier.shared.configure()
         NotificationCenter.default.addObserver(self, selector: #selector(serverAppsDidChange), name: .serverAppsDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(downloadDidStart), name: .downloadDidStart, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(serverCredentialsRejected), name: .serverCredentialsRejected, object: nil)
         rebuildServerAppsMenu()
         presentInitialWindow(forLaunch: true)
+    }
+
+    func applicationDidBecomeActive(_: Notification) {
+        // Keep the Dock badge fresh when the user returns to the app; does nothing while the monitor is stopped.
+        NotificationMonitor.shared.refreshNow()
     }
 
     func applicationDockMenu(_: NSApplication) -> NSMenu? {
@@ -122,7 +128,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Task {
             do {
                 switch try await ServerConnection.validate(server) {
-                    case .supported:
+                    case let .supported(capabilities):
                         logger.info("Server supported; presenting web window")
                         // At launch the validate round-trip runs after AppKit's local restoration, so any restored
                         // web windows are already tracked; open a fresh one only when nothing was restored. A
@@ -132,9 +138,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                         }
 
                         await ServerConnection.refreshNavigationApps(using: server)
+                        // Begin (or restart) tracking unread notifications for the Dock badge and banners.
+                        NotificationMonitor.shared.start(for: server, capabilities: capabilities)
 
                     case let .unsupported(version):
                         logger.notice("Server at \(serverAddress.absoluteString) runs unsupported version \(version)")
+                        NotificationMonitor.shared.stop()
+
                         if forLaunch {
                             closeWebViewWindows()
                         }
@@ -144,16 +154,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             } catch RainmakerError.credentialsRequired, RainmakerError.unexpectedStatus(code: 401) {
                 // The stored app password was revoked on the server; discard it and require a new login.
-                logger.notice("Stored credentials rejected (401); clearing keychain and requiring sign-in")
-                Keychain.clearAll()
-
-                if forLaunch {
-                    closeWebViewWindows()
-                }
-
-                presentWindow(withIdentifier: "ServerAddressWindowController")
+                requireSignIn()
             } catch {
                 logger.error("Could not reach server: \(error.localizedDescription)")
+                NotificationMonitor.shared.stop()
+
                 if forLaunch {
                     closeWebViewWindows()
                 }
@@ -164,10 +169,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// `requireSignIn()` discards the rejected credentials and returns the app to the sign-in screen.
+    ///
+    /// `presentInitialWindow(forLaunch:)` calls it when validation reports the stored app password was revoked, and the `serverCredentialsRejected` observer calls it when `NotificationMonitor`'s event stream detects the same during a session. It stops the monitor, clears the keychain, closes any web windows left on the now-unusable server, and presents `ServerAddressWindowController`.
+    private func requireSignIn() {
+        logger.notice("Credentials rejected; clearing keychain and requiring sign-in")
+        NotificationMonitor.shared.stop()
+        Keychain.clearAll()
+        closeWebViewWindows()
+        presentWindow(withIdentifier: "ServerAddressWindowController")
+    }
+
+    /// `serverCredentialsRejected()` returns the app to sign-in when `NotificationMonitor` reports its stream was rejected because the stored app password was revoked.
+    @objc
+    private func serverCredentialsRejected() {
+        logger.notice("Notification monitor reported rejected credentials")
+        requireSignIn()
+    }
+
     /// `hasOpenWebWindow` is `true` while at least one web window is open, including any AppKit restored at launch.
     ///
-    /// `presentInitialWindow(forLaunch:)` reads it at launch to avoid opening a duplicate window when AppKit already restored one.
-    private var hasOpenWebWindow: Bool {
+    /// `presentInitialWindow(forLaunch:)` reads it at launch to avoid opening a duplicate window when AppKit already restored one, and `NotificationMonitor` reads it to suppress its own banners while the embedded web interface can surface its own.
+    var hasOpenWebWindow: Bool {
         windowControllers.contains { $0 is WebWindowController }
     }
 
@@ -242,6 +265,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             logger.debug("No server address or stored credentials to revoke an app password for")
         }
+
+        // Stop tracking notifications and clear the Dock badge before the credentials it relies on are removed.
+        NotificationMonitor.shared.stop()
 
         for window in NSApplication.shared.windows {
             window.close()

--- a/Cirruscope/Notifications/NotificationMonitor.swift
+++ b/Cirruscope/Notifications/NotificationMonitor.swift
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 Iva Horn
+// SPDX-License-Identifier: MIT
+
+import AppKit
+import os
+import Rainmaker
+
+/// `NotificationMonitor` is the app-wide facility that keeps the Dock badge and notification-center banners in sync with the unread Nextcloud notifications of the connected server, as issue #41 requires.
+///
+/// It observes server-side changes through Rainmaker's `Server.events(_:)`, which prefers the `notify_push` WebSocket when the server offers it and otherwise polls every 30 seconds. Each event is only a hint, so the monitor reacts by re-fetching the full notification list via `Server.notifications()`; the unread count is that list's `count`, since the server returns exactly the notifications still queued for the user.
+/// It broadcasts `Notification.Name.unreadNotificationCountDidChange` whenever the count changes so other parts of the app can react, and posts `Notification.Name.serverCredentialsRejected` when the stream reports the stored app password was revoked so `AppDelegate` can require a new sign-in.
+@MainActor
+final class NotificationMonitor {
+    /// `shared` is the process-wide monitor, retained for the app's lifetime so it can own the long-lived event stream.
+    static let shared = NotificationMonitor()
+
+    /// `logger` records monitoring activity under the `NotificationMonitor` category.
+    let logger = Logger(for: NotificationMonitor.self)
+
+    /// `unreadCount` is the number of notifications currently queued for the user, exposed read-only so only the monitor mutates it.
+    ///
+    /// There is no read/unread flag on a Nextcloud notification: the server returns exactly the pending ones, so their count is the unread count shown on the Dock badge.
+    private(set) var unreadCount = 0
+
+    /// `server` is the connected server the monitor is currently observing, or `nil` while stopped, retained so `refreshNow()` can re-fetch on demand.
+    private var server: Server?
+
+    /// `task` is the retained consumer of the event stream, cancelled by `stop()`.
+    private var task: Task<Void, Never>?
+
+    /// `banneredIDs` holds the identifiers of notifications already turned into a banner, so re-fetching an unchanged queue does not post duplicate banners.
+    private var banneredIDs: Set<Int> = []
+
+    /// `endpointUnavailable` is set once the notifications endpoint reports it is absent so the monitor stops re-fetching and logging on every subsequent event; it is cleared on the next reconnect.
+    private var endpointUnavailable = false
+
+    /// `start(for:capabilities:)` begins observing `server` when it advertises the notifications capability, performing an immediate check and then reacting to every change.
+    ///
+    /// It gates on the `Notifications` capability because `Server.notifications()` only exists while the server's notifications app is enabled; when it is absent the monitor stays stopped and the badge is cleared. Any previously observed server is stopped first, so switching accounts never leaves two streams running.
+    func start(for server: Server, capabilities: CapabilitySet) {
+        guard capabilities.contains(Notifications.self) else {
+            logger.notice("Notifications capability absent; not starting monitor")
+            stop()
+            return
+        }
+
+        logger.info("Starting notification monitor")
+        stop()
+        self.server = server
+        // Request authorization now so banners can appear even when no web window is ever opened.
+        UserNotifier.shared.requestAuthorization()
+
+        task = Task {
+            do {
+                // The stream emits `.connected` on subscription, which drives the launch-time check as soon as possible.
+                for try await event in server.events([.notifications]) {
+                    switch event {
+                        case .connected:
+                            self.endpointUnavailable = false
+                            await self.refresh()
+
+                        case .notifications:
+                            await self.refresh()
+
+                        default:
+                            break
+                    }
+                }
+            } catch is CancellationError {
+                // Expected when `stop()` cancels the task; nothing to do.
+            } catch RainmakerError.credentialsRequired, RainmakerError.unexpectedStatus(code: 401) {
+                self.logger.notice("Notification stream rejected credentials; requiring sign-in")
+                self.stop()
+                NotificationCenter.default.post(name: .serverCredentialsRejected, object: nil)
+            } catch {
+                self.logger.error("Notification stream ended: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// `stop()` ends observation, clears the Dock badge, and resets the count to zero.
+    ///
+    /// `AppDelegate` calls it when the server becomes unusable — unsupported, unreachable, signed out, or with revoked credentials — and `start(for:capabilities:)` calls it before adopting a new server.
+    func stop() {
+        task?.cancel()
+        task = nil
+        server = nil
+        banneredIDs.removeAll()
+        endpointUnavailable = false
+        unreadCount = 0
+        updateDockBadge()
+        NotificationCenter.default.post(name: .unreadNotificationCountDidChange, object: nil)
+    }
+
+    /// `refreshNow()` re-fetches the notifications immediately, used by `AppDelegate.applicationDidBecomeActive(_:)` to keep the badge fresh when the user returns to the app.
+    ///
+    /// It does nothing while the monitor is stopped.
+    func refreshNow() {
+        guard server != nil else {
+            return
+        }
+
+        Task {
+            await refresh()
+        }
+    }
+
+    /// `refresh()` fetches the current notifications, updates the count and Dock badge, and posts banners for newly arrived ones.
+    ///
+    /// A `notFound` result means the notifications app was disabled after the capability check, so the badge is cleared and further re-fetching is suppressed until the next reconnect. Rejected credentials stop the monitor and ask `AppDelegate` for a new sign-in; any other error is transient and leaves the current badge untouched so a temporary network blip does not clear it.
+    private func refresh() async {
+        guard let server, endpointUnavailable == false else {
+            return
+        }
+
+        do {
+            let items = try await server.notifications()
+            logger.debug("Fetched \(items.count, privacy: .public) notification(s)")
+            unreadCount = items.count
+            updateDockBadge()
+            NotificationCenter.default.post(name: .unreadNotificationCountDidChange, object: nil)
+            postBanners(for: items)
+        } catch RainmakerError.notFound {
+            logger.notice("Notifications endpoint unavailable; clearing badge")
+            endpointUnavailable = true
+            unreadCount = 0
+            updateDockBadge()
+            NotificationCenter.default.post(name: .unreadNotificationCountDidChange, object: nil)
+        } catch RainmakerError.credentialsRequired, RainmakerError.unexpectedStatus(code: 401) {
+            logger.notice("Notification refresh rejected credentials; requiring sign-in")
+            stop()
+            NotificationCenter.default.post(name: .serverCredentialsRejected, object: nil)
+        } catch {
+            logger.notice("Could not refresh notifications: \(error.localizedDescription)")
+        }
+    }
+
+    /// `updateDockBadge()` reflects `unreadCount` onto the Dock icon, clearing the badge when there is nothing unread or no server is configured.
+    ///
+    /// The count is rendered with the current locale's digits and capped at `"999+"` so the badge stays narrow. `NSDockTile.display()` is called after each change to have the Dock repaint the tile promptly. Note that the badge only appears at all once notification authorization includes `.badge`, which `UserNotifier.requestAuthorization()` requests; macOS gates the app-icon badge — the Dock tile included — behind that option for any `UNUserNotificationCenter` client.
+    private func updateDockBadge() {
+        defer {
+            NSApp.dockTile.display()
+        }
+
+        guard Settings.serverAddress != nil, unreadCount > 0 else {
+            NSApp.dockTile.badgeLabel = nil
+            return
+        }
+
+        let label = unreadCount > 999 ? "999+" : unreadCount.formatted()
+        logger.debug("Updating Dock badge to \(label, privacy: .public)")
+        NSApp.dockTile.badgeLabel = label
+    }
+
+    /// `bannersAllowed` is `true` only while no web window is open, so the monitor's banners do not duplicate the ones the embedded Nextcloud web interface raises through `UserNotifier`'s web bridge.
+    ///
+    /// The Dock badge updates regardless; only the banners are suppressed while a web window can surface its own.
+    private var bannersAllowed: Bool {
+        (NSApp.delegate as? AppDelegate)?.hasOpenWebWindow == false
+    }
+
+    /// `postBanners(for:)` posts a banner for each notification not seen in the previous fetch, then records the current set so the same notification never banners twice.
+    ///
+    /// It records the seen identifiers even while banners are suppressed, so re-enabling them later does not retroactively banner notifications that arrived meanwhile.
+    private func postBanners(for items: [NotificationItem]) {
+        defer {
+            banneredIDs = Set(items.map(\.id))
+        }
+
+        guard bannersAllowed, let serverAddress = Settings.serverAddress else {
+            return
+        }
+
+        for item in items where banneredIDs.contains(item.id) == false {
+            UserNotifier.shared.postServerNotification(item, serverAddress: serverAddress)
+        }
+    }
+}

--- a/Cirruscope/Settings/Settings.swift
+++ b/Cirruscope/Settings/Settings.swift
@@ -324,4 +324,10 @@ extension Notification.Name {
 
     /// `downloadDidStart` is posted by `DownloadManager` when a new transfer begins so `AppDelegate` can open and bring the Downloads window to the foreground.
     static let downloadDidStart = Notification.Name("DownloadDidStart")
+
+    /// `unreadNotificationCountDidChange` is posted by `NotificationMonitor` whenever the unread server-notification count changes so other parts of the app can react without reaching into the monitor.
+    static let unreadNotificationCountDidChange = Notification.Name("UnreadNotificationCountDidChange")
+
+    /// `serverCredentialsRejected` is posted by `NotificationMonitor` when its event stream reports the stored app password was revoked so `AppDelegate` can clear the keychain and require a new sign-in.
+    static let serverCredentialsRejected = Notification.Name("ServerCredentialsRejected")
 }

--- a/Cirruscope/UserNotifier.swift
+++ b/Cirruscope/UserNotifier.swift
@@ -3,6 +3,7 @@
 
 import AppKit
 import os
+import Rainmaker
 import UserNotifications
 import WebKit
 
@@ -26,6 +27,11 @@ final class UserNotifier: NSObject, UNUserNotificationCenterDelegate {
     /// It is `nonisolated` so the `nonisolated` delegate callback that inspects a clicked notification can read it.
     private nonisolated static let downloadFilePathKey = "downloadFilePath"
 
+    /// `serverNotificationLinkKey` is the `userInfo` key under which `postServerNotification(_:serverAddress:)` stores a server notification's absolute link so a click can open it in a web window.
+    ///
+    /// It is `nonisolated` so the `nonisolated` delegate callback that inspects a clicked notification can read it.
+    private nonisolated static let serverNotificationLinkKey = "serverNotificationLink"
+
     /// `configure()` registers `shared` as the `UNUserNotificationCenter` delegate so notifications are presented even while Cirruscope is the active app and so clicks are delivered here.
     ///
     /// `AppDelegate.applicationDidFinishLaunching(_:)` calls it once, before the launch sequence completes, as `UNUserNotificationCenter` requires its delegate to be set by then.
@@ -33,11 +39,12 @@ final class UserNotifier: NSObject, UNUserNotificationCenterDelegate {
         UNUserNotificationCenter.current().delegate = self
     }
 
-    /// `requestAuthorization()` asks the user for permission to show alerts and play sounds, prompting only the first time the authorization state is undetermined.
+    /// `requestAuthorization()` asks the user for permission to show alerts, play sounds, and badge the app icon, prompting only the first time the authorization state is undetermined.
     ///
     /// `WebViewController` calls it when a web window opens so the prompt appears in the context of a connected server rather than at launch.
+    /// The `.badge` option is essential and not merely for `UNNotificationContent` badges: once an app becomes a `UNUserNotificationCenter` client, macOS gates the app-icon badge — including the `NSApp.dockTile.badgeLabel` count `NotificationMonitor` sets — behind the notification "Badges" setting, which this option authorizes. Without it the Dock badge is silently suppressed even though the label is assigned.
     func requestAuthorization() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { [logger] granted, error in
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { [logger] granted, error in
             if let error {
                 logger.error("Notification authorization failed: \(error.localizedDescription)")
             } else if granted == false {
@@ -75,6 +82,22 @@ final class UserNotifier: NSObject, UNUserNotificationCenterDelegate {
         UNUserNotificationCenter.current().add(request)
     }
 
+    /// `postServerNotification(_:serverAddress:)` posts a banner for a Nextcloud server notification, remembering its link so a click opens it in a web window.
+    ///
+    /// `NotificationMonitor` calls it for each newly arrived notification. The request identifier is derived from the notification's server id so the same notification, seen again on a later fetch, replaces its banner rather than posting a duplicate. The link is resolved against `serverAddress` because the server returns it relative to the instance root.
+    func postServerNotification(_ item: NotificationItem, serverAddress: URL) {
+        let content = UNMutableNotificationContent()
+        content.title = item.subject
+        content.body = item.message
+
+        if let url = URL(string: item.link, relativeTo: serverAddress)?.absoluteURL {
+            content.userInfo = [Self.serverNotificationLinkKey: url.absoluteString]
+        }
+
+        let request = UNNotificationRequest(identifier: "server-notification-\(item.id)", content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request)
+    }
+
     nonisolated func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .sound, .list])
     }
@@ -84,10 +107,13 @@ final class UserNotifier: NSObject, UNUserNotificationCenterDelegate {
         let userInfo = response.notification.request.content.userInfo
         let webNotificationID = userInfo["webNotificationID"] as? String
         let downloadFilePath = userInfo[Self.downloadFilePathKey] as? String
+        let serverNotificationLink = userInfo[Self.serverNotificationLinkKey] as? String
 
         Task { @MainActor in
             if let downloadFilePath {
                 self.revealDownloadedFile(atPath: downloadFilePath)
+            } else if let serverNotificationLink, let url = URL(string: serverNotificationLink) {
+                self.openServerNotificationLink(url)
             } else {
                 self.activate(identifier: identifier, webNotificationID: webNotificationID)
             }
@@ -121,5 +147,14 @@ final class UserNotifier: NSObject, UNUserNotificationCenterDelegate {
     private func revealDownloadedFile(atPath path: String) {
         NSApp.activate()
         NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+    }
+
+    /// `openServerNotificationLink(_:)` brings the app forward and opens the server notification's target in a web window.
+    ///
+    /// `userNotificationCenter(_:didReceive:withCompletionHandler:)` calls it when the clicked notification was posted by `postServerNotification(_:serverAddress:)`.
+    @MainActor
+    private func openServerNotificationLink(_ url: URL) {
+        NSApp.activate(ignoringOtherApps: true)
+        (NSApp.delegate as? AppDelegate)?.presentWebViewWindow(targetURL: url)
     }
 }


### PR DESCRIPTION
Closes #41.

Keeps the Dock badge and macOS notification banners in sync with the connected server's unread Nextcloud notifications, using Rainmaker's server-event stream (`Server.events(_:)`), which prefers the `notify_push` WebSocket and otherwise polls. `NotificationMonitor` re-fetches the notification list on each event, drives `NSApp.dockTile.badgeLabel`, and posts banners via `UserNotifier` while no web window is open.

## Notable fix

The Dock badge would never render even though the count was set correctly. Root cause: once an app is a `UNUserNotificationCenter` client, macOS gates the app-icon badge (the `NSDockTile` badge included) behind the notification **Badges** setting, and `UserNotifier.requestAuthorization()` requested only `[.alert, .sound]`. Requesting `.badge` fixes it. A `NSApp.dockTile.display()` was also added to force a prompt repaint, plus a couple of debug logs (the happy path was previously silent).

## Notes

- Rebased onto `develop`; the two working commits are squashed into one.
- Requires Rainmaker **3.3.0** (server events / `notifications()` API); `Package.resolved` is bumped from 3.2.0.
- develop's logout was refactored into `AppDelegate.logOut()`; that method now calls `NotificationMonitor.shared.stop()` so logout still stops tracking and clears the badge.

## Test plan

- [x] Builds against `develop` (Debug).
- [x] On launch with 3 pending notifications, the monitor fetches them and sets the Dock badge to `3` (verified via unified logging and on-screen).
- [ ] Reviewer: sign in (develop's new keychain-access-group requires a fresh login) and confirm the `3` badge appears.
