### PR TITLE
Add Developer Certificate of Origin policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+<!-- What does this pull request do, and why? -->
+
+## Checklist
+
+- [ ] Every commit is signed off (`git commit -s`) per the [DCO](./CONTRIBUTING.md#developer-certificate-of-origin)
+- [ ] AI tools have been used in the process of creating this contribution (see [CONTRIBUTING.md](./CONTRIBUTING.md#ai-assisted-contributions))
+- [ ] `swiftformat .` run
+- [ ] `reuse lint` passes

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2026 Iva Horn
+# SPDX-License-Identifier: MIT
+
+name: DCO
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Signed-off-by Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check Signed-off-by trailer
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.event.after }}
+        run: |
+          set -e
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base="$BASE_SHA"
+            head="$HEAD_SHA"
+          else
+            base="$PUSH_BEFORE"
+            head="$PUSH_AFTER"
+          fi
+
+          if [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            # Newly created branch: no prior "before" commit to diff against.
+            commits="$head"
+          else
+            commits="$(git log --no-merges --format=%H "$base..$head")"
+          fi
+
+          missing=""
+          for sha in $commits; do
+            if ! git log -1 --format=%B "$sha" | grep -qE '^Signed-off-by: .+ <.+>$'; then
+              missing="$missing $sha"
+            fi
+          done
+
+          if [ -n "$missing" ]; then
+            echo "The following commits are missing a 'Signed-off-by' trailer required by this project's Developer Certificate of Origin policy (see CONTRIBUTING.md):"
+            for sha in $missing; do
+              echo "  - $sha $(git log -1 --format='%s' "$sha")"
+            done
+            exit 1
+          fi
+
+          echo "All commits in range are signed off."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ This project is checked for [REUSE](https://reuse.software/) Specification 3.3 c
   git log --follow --format=%ad --date=format:%Y -- <path> | tail -1
   ```
 - Files that cannot safely hold an inline comment — binaries, pure JSON, or anything Xcode/SwiftPM/Icon Composer regenerates or rewrites through its own GUI or tooling (the asset catalog, the `AppIcon.icon` bundle, `project.pbxproj`, `contents.xcworkspacedata`, `Package.resolved`, `Main.storyboard`, `Info.plist`, `PrivacyInfo.xcprivacy`, `Localizable.xcstrings`, `.swift-version`) — are covered by a `[[annotations]]` entry in `REUSE.toml` instead. Add new files of these kinds to an existing matching `path` glob there only if its year already matches, or a new annotation block otherwise; never hand-edit an SPDX comment into them.
-- `Cirruscope/AppIcon.icon/Assets/White Nextcloud Mark.svg` is the one deliberate exception: it is Nextcloud's own trademark, not this project's work, so its `REUSE.toml` entry attributes it to `Nextcloud GmbH` under `LicenseRef-Nextcloud-Trademark` (see `LICENSES/LicenseRef-Nextcloud-Trademark.txt`) rather than `Iva Horn`/`MIT`.
+- `.github/PULL_REQUEST_TEMPLATE.md` is one exception: GitHub pre-fills a new pull request's description textarea with this file's raw, unrendered content, so an inline HTML comment header would show up as literal visible clutter for every contributor opening a PR — it is covered by a `REUSE.toml` entry instead, even though Markdown normally takes an inline header.
 - Whenever a change adds a new file, give it SPDX coverage immediately — an inline header or a `REUSE.toml` entry — rather than leaving it for later.
 - Always run `reuse lint` in the project root directory after applying changes (install via `brew install reuse` if missing), and confirm it reports "Congratulations! Your project is compliant with version 3.3 of the REUSE Specification" before considering the change complete.
 
@@ -175,6 +175,7 @@ Use `log show` to read logs already recorded in a past time range, and `log stre
 - Do not commit automatically.
 - Suggest commit title after applying changes. If the changes relate to specific GitHub issues, mention them.
 - Suggest commit description after applying changes.
+- Every commit must carry a `Signed-off-by:` trailer per this project's [Developer Certificate of Origin](./CONTRIBUTING.md#developer-certificate-of-origin) policy, matching the git identity of whoever is being committed on behalf of in the current session (`git config user.name`/`user.email` — never a hardcoded name, since a different contributor's session must sign off as themselves), in addition to any `Co-Authored-By:` trailer already appended.
 
 ## Pull Request Instructions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+<!--
+SPDX-FileCopyrightText: 2026 Iva Horn
+SPDX-License-Identifier: MIT
+-->
+
+# Contributing to Cirruscope
+
+Thanks for your interest in contributing. This document is written for developers, in the same spirit as [README.md](./README.md).
+
+## Developer Certificate of Origin
+
+Every contribution to Cirruscope must be signed off under the [Developer Certificate of Origin](https://developercertificate.org/) (DCO). By signing off a commit, you certify that you wrote it (or otherwise have the right to submit it) under this project's license.
+
+Add a `Signed-off-by: Your Name <your@email.com>` trailer to every commit message, using the name and email address you want associated with the contribution:
+
+```
+git commit -s -m "Your commit message"
+```
+
+To avoid typing `-s` every time, set up a git alias:
+
+```
+git config --global alias.ci 'commit -s'
+```
+
+If you forgot to sign off a commit you already made, amend it:
+
+```
+git commit --amend -s
+```
+
+For multiple commits on a branch, sign them all off at once against the branch you're merging into (e.g. `develop`):
+
+```
+git rebase --exec 'git commit --amend --no-edit -s' develop
+```
+
+then force-push your branch to update the pull request.
+
+[.github/workflows/dco.yml](.github/workflows/dco.yml) checks every commit on every push and pull request against `main`/`develop` for a `Signed-off-by:` trailer, and must pass before a pull request can be merged.
+
+> **Note:** GitHub's default "Squash and merge" only carries commit *titles* into the squashed commit, dropping `Signed-off-by:` trailers along the way. Either merge with "Create a merge commit" instead, or manually keep a `Signed-off-by:` line in the squash commit message before confirming the merge.
+
+## AI-Assisted Contributions
+
+If you used an AI tool (e.g. GitHub Copilot, ChatGPT, Claude, or similar) to help write any part of a contribution — code, tests, documentation, or commit messages — check the corresponding box in the pull request template.
+
+Disclosure doesn't lower the bar: you must be able to explain every part of your contribution — what it does, why it's written the way it is, and any trade-offs involved — in review, and you are personally accountable for it regardless of how it was produced. Do not open a pull request for code you have not reviewed and understood yourself. This doesn't replace the Developer Certificate of Origin above either: signing off a commit still certifies that you have the right to submit its content.
+
+## Code Quality Checks
+
+- Run `swiftformat .` before committing; CI lints with `swiftformat --lint`.
+- New files need SPDX copyright/license headers; run `reuse lint` to confirm compliance.
+- See [AGENTS.md](./AGENTS.md) for the full set of project conventions followed by human and AI contributors alike.
+
+## Contribution Workflow
+
+1. Fork the repository or create a branch.
+2. Open a pull request against `develop`.
+3. Make sure CI (SwiftFormat, REUSE, DCO) is green before requesting review.
+
+## License
+
+By contributing to Cirruscope, you agree that your contributions will be licensed under this project's [LICENSE](./LICENSE) (MIT).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SPDX-License-Identifier: MIT
 
 [![SwiftFormat](https://github.com/i2h3/cirruscope/actions/workflows/swiftformat.yml/badge.svg)](https://github.com/i2h3/cirruscope/actions/workflows/swiftformat.yml)
 [![REUSE](https://github.com/i2h3/cirruscope/actions/workflows/reuse.yml/badge.svg)](https://github.com/i2h3/cirruscope/actions/workflows/reuse.yml)
+[![DCO](https://github.com/i2h3/cirruscope/actions/workflows/dco.yml/badge.svg)](https://github.com/i2h3/cirruscope/actions/workflows/dco.yml)
 [![Website](https://github.com/i2h3/cirruscope/actions/workflows/website.yml/badge.svg)](https://github.com/i2h3/cirruscope/actions/workflows/website.yml)
 
 An app-like Nextcloud experience on macOS.
@@ -99,6 +100,10 @@ Double-click the file, then approve it under **System Settings ▸ General ▸ D
 
 This is an unofficial third-party app out of the Nextcloud community.
 It is not associated with or endorsed by Nextcloud GmbH.
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the workflow — commits must be signed off under the Developer Certificate of Origin, and CI must pass before a pull request can be merged.
 
 ## License
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -95,3 +95,13 @@ path = "Website/**"
 precedence = "override"
 SPDX-FileCopyrightText = "2026 Iva Horn"
 SPDX-License-Identifier = "MIT"
+
+# GitHub pre-fills a new pull request's description textarea (unrendered, so
+# HTML comments show up as literal visible text) with this file's raw content,
+# so it is annotated here instead of carrying an inline header like other
+# Markdown files.
+[[annotations]]
+path = ".github/PULL_REQUEST_TEMPLATE.md"
+precedence = "override"
+SPDX-FileCopyrightText = "2026 Iva Horn"
+SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
## Description

Introduces a Developer Certificate of Origin (DCO) policy, similar to nextcloud/desktop:

- New `CONTRIBUTING.md` documenting the DCO requirement (`git commit -s`), code quality checks, the contribution workflow, and a disclosure/accountability requirement for AI-assisted contributions.
- New `.github/workflows/dco.yml` CI check that fails a push/PR to `main`/`develop` if any commit is missing a `Signed-off-by` trailer.
- New `.github/PULL_REQUEST_TEMPLATE.md` with a checklist covering sign-off, AI tool disclosure, SwiftFormat, and REUSE.
- `AGENTS.md` and `README.md` updated to reference the new policy; `REUSE.toml`/`AGENTS.md` updated so the PR template's SPDX attribution lives in `REUSE.toml` instead of an inline header (which would otherwise show up as raw clutter in GitHub's PR description box).

## Checklist

- [x] Every commit is signed off (`git commit -s`) per the [DCO](./CONTRIBUTING.md#developer-certificate-of-origin)
- [x] AI tools have been used in the process of creating this contribution (see [CONTRIBUTING.md](./CONTRIBUTING.md#ai-assisted-contributions))
- [x] `swiftformat .` run
- [x] `reuse lint` passes