### PR TITLE
Fixed undesired logout on redirect to login URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ You are an experienced software engineer specialized on native apps for macOS wr
 - Documentation comments should have one empty line at their top and their bottom each.
 - Documentation comments must not wrap at a fixed column count but when a sentence is finished. Line lengths do not matter in documentation comments. A full sentence should always be written into a single line.
 - Never wrap arguments in func declarations or calls.
+- Instead of declaring multiple values in a single guard-let statement, write one dedicated guard-let statement per value.
 - Always run `swiftformat .` in the project root directory after applying changes.
 
 ## Building and Signing

--- a/Cirruscope/AppDelegate/AppDelegate.swift
+++ b/Cirruscope/AppDelegate/AppDelegate.swift
@@ -172,14 +172,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// `requireSignIn()` discards the rejected credentials and returns the app to the sign-in screen.
+    /// `requireSignIn()` discards the rejected credentials, alerts the user, and returns the app to the sign-in screen.
     ///
-    /// `presentInitialWindow(forLaunch:)` calls it when validation reports the stored app password was revoked, and the `serverCredentialsRejected` observer calls it when `NotificationMonitor`'s event stream detects the same during a session. It stops the monitor, clears the keychain, closes any web windows left on the now-unusable server, and presents `ServerAddressWindowController`.
-    private func requireSignIn() {
+    /// `presentInitialWindow(forLaunch:)` calls it when validation reports the stored app password was revoked, the `serverCredentialsRejected` observer calls it when `NotificationMonitor`'s event stream detects the same during a session, and `WebViewController+WKNavigationDelegate` calls it when a silent retry of the server's login page with the stored app password lands back on the login page a second time. In every case the app is signing the user out on its own initiative rather than because the user asked to, so — unlike `logOut()` — it shows an alert explaining why before presenting the sign-in screen. It stops the monitor, clears the keychain, closes any web windows left on the now-unusable server, and presents `ServerAddressWindowController`. It does not attempt to revoke the app password: the server has already rejected it, so revoking it again would be pointless.
+    func requireSignIn() {
         logger.notice("Credentials rejected; clearing keychain and requiring sign-in")
         NotificationMonitor.shared.stop()
         Keychain.clearAll()
         closeWebViewWindows()
+
+        presentAlert(
+            title: String(localized: "Signed Out", comment: "Alert title shown when the app signs the user out on its own because the server rejected the stored credentials."),
+            message: String(localized: "Your Nextcloud credentials are no longer valid, so Cirruscope signed you out. Sign in again to continue.", comment: "Alert message shown when the app signs the user out because the server rejected the stored credentials.")
+        )
+
         presentWindow(withIdentifier: "ServerAddressWindowController")
     }
 

--- a/Cirruscope/Models/ServerAppTransferObject.swift
+++ b/Cirruscope/Models/ServerAppTransferObject.swift
@@ -18,11 +18,4 @@ struct ServerAppTransferObject: Codable, Identifiable, Sendable {
 
     /// `name` is the localized display name of the app, used as its menu item label.
     let name: String
-
-    init(id: String, order: Int, href: String, name: String) {
-        self.id = id
-        self.order = order
-        self.href = href
-        self.name = name
-    }
 }

--- a/Cirruscope/Web/WebViewController+WKNavigationDelegate.swift
+++ b/Cirruscope/Web/WebViewController+WKNavigationDelegate.swift
@@ -5,7 +5,7 @@ import AppKit
 import os
 import WebKit
 
-/// `WebViewController`'s conformance to `WKNavigationDelegate` confines the embedded `WKWebView`'s main frame to the configured Nextcloud server, hands off any main-frame navigation that targets a different host to the user's default browser via `NSWorkspace`, turns responses the web view cannot display or that arrive as attachments into downloads, reveals the storyboard-hidden web view once its initial page load has completed, and treats the web view landing on the server's own logout or login page as an app-level logout, so the app never keeps behaving as signed in once the web session it was mirroring is gone.
+/// `WebViewController`'s conformance to `WKNavigationDelegate` confines the embedded `WKWebView`'s main frame to the configured Nextcloud server, hands off any main-frame navigation that targets a different host to the user's default browser via `NSWorkspace`, turns responses the web view cannot display or that arrive as attachments into downloads, reveals the storyboard-hidden web view once its initial page load has completed, treats the web view navigating to the server's own logout link as an app-level logout, and silently retries with the stored app password when the web view is instead redirected to the server's login page, since that only means the browser session's cookie expired, not that the app's own stored credentials are invalid.
 ///
 /// Any navigation that becomes a download is handed to `DownloadManager.shared`, which takes over as the transfer's delegate so it continues even if this web window closes.
 /// Every method here logs its entry and each outcome at debug level so the navigation behaviour of a specific window — identified by the appended `logID` — can be reconstructed from a log capture when tracing misbehaviour.
@@ -48,19 +48,53 @@ extension WebViewController: WKNavigationDelegate {
             return
         }
 
-        // The web view's browser session and the app's own stored Login Flow v2 credentials are independent: Nextcloud's
-        // logout invalidates only the current browser session's token, and landing on the login page (from session
-        // expiry, an admin revoking the session, or the logout link itself) means the browser session is gone either
-        // way. Catch both so the app never keeps behaving as signed in once that's true. The URL always carries a
-        // per-request CSRF token, so only the last path component can be matched, not the full URL.
+        // Nextcloud's own "Log out" link always navigates to a URL whose last path component is "logout" (the URL
+        // also carries a per-request CSRF token, so only the last path component can be matched, not the full URL).
+        // That is an unambiguous, explicit sign-out, so it is still treated as an app-level logout too.
         if let url = navigationAction.request.url,
            let host = url.host,
            let serverHost = AccountStore.shared.serverAddress?.host,
            host.caseInsensitiveCompare(serverHost) == .orderedSame,
-           ["logout", "login"].contains(url.lastPathComponent.lowercased())
+           url.lastPathComponent.lowercased() == "logout"
         {
-            logger.notice("Navigation action targets the configured server's own \(url.lastPathComponent) page; logging out at the app level too and cancelling the navigation (WebViewController \(self.logID))")
+            logger.notice("Navigation action targets the configured server's own logout page; logging out at the app level too and cancelling the navigation (WebViewController \(self.logID))")
             (NSApp.delegate as? AppDelegate)?.logOut()
+            decisionHandler(.cancel)
+            return
+        }
+
+        // Landing on the login page by itself is NOT treated as a logout: the web view's browser-session cookie and
+        // the app's own stored Login Flow v2 app password are independent, and the browser session alone expires
+        // routinely — e.g. Nextcloud redirects an already-authenticated request to `/login?redirect_url=...`
+        // whenever that cookie has lapsed, which has nothing to do with whether the stored app password used for
+        // the app's own background REST calls is still valid. So instead of forcing the user to sign in again, the
+        // originally-requested page (decoded from `redirect_url`, or the server address when there is none) is
+        // silently reloaded with that stored app password attached, the same way the initial page load already
+        // signs the web view in with no visible login step. Only if that retry itself lands back on the login page
+        // — recorded via `hasRetriedLoginRedirect` — is the stored app password treated as genuinely rejected, at
+        // which point `AppDelegate.requireSignIn()` takes over: the softer sign-out that, unlike `logOut()`, does
+        // not try to revoke an already-invalid credential and alerts the user why they were signed out.
+        if let url = navigationAction.request.url,
+           let host = url.host,
+           let serverHost = AccountStore.shared.serverAddress?.host,
+           host.caseInsensitiveCompare(serverHost) == .orderedSame,
+           url.lastPathComponent.lowercased() == "login"
+        {
+            guard hasRetriedLoginRedirect == false else {
+                logger.notice("Silently retrying the login page with the stored app password already failed once; the app password appears to be rejected, so requiring sign-in (WebViewController \(self.logID))")
+                (NSApp.delegate as? AppDelegate)?.requireSignIn()
+                decisionHandler(.cancel)
+                return
+            }
+
+            hasRetriedLoginRedirect = true
+            let target = redirectTarget(from: url) ?? AccountStore.shared.serverAddress
+            logger.notice("Navigation action targets the configured server's own login page; retrying \(target?.absoluteString ?? "no URL") with the stored app password instead of prompting the user and cancelling the navigation (WebViewController \(self.logID))")
+
+            if let target {
+                webView.load(authenticatedRequest(for: target))
+            }
+
             decisionHandler(.cancel)
             return
         }
@@ -78,6 +112,19 @@ extension WebViewController: WKNavigationDelegate {
         NSWorkspace.shared.open(url)
         logger.debug("Navigation action targets external host \(host); opened it in the system browser and returning .cancel (WebViewController \(self.logID))")
         decisionHandler(.cancel)
+    }
+
+    /// `redirectTarget(from:)` decodes the `redirect_url` query parameter Nextcloud attaches to its login page — the page the user was actually trying to reach before the browser session's cookie expired — resolved against the configured server address, or `nil` when the login URL carries no such parameter.
+    ///
+    /// `webView(_:decidePolicyFor:decisionHandler:)` uses this to know what to silently reload with the stored app password once the login page's redirect is intercepted, falling back to the server address itself when this returns `nil`.
+    private func redirectTarget(from loginURL: URL) -> URL? {
+        guard let components = URLComponents(url: loginURL, resolvingAgainstBaseURL: false),
+              let redirectPath = components.queryItems?.first(where: { $0.name == "redirect_url" })?.value
+        else {
+            return nil
+        }
+
+        return URL(string: redirectPath, relativeTo: AccountStore.shared.serverAddress)?.absoluteURL
     }
 
     @objc(webView:decidePolicyForNavigationResponse:decisionHandler:)
@@ -155,6 +202,10 @@ extension WebViewController: WKNavigationDelegate {
 
     func webView(_: WKWebView, didFinish _: WKNavigation!) {
         logger.debug("Navigation finished; revealing web view (WebViewController \(self.logID))")
+
+        // A successful load means any silent login-redirect retry (see `decidePolicyFor navigationAction`) worked,
+        // or none was needed; clear the flag so a later, unrelated session expiry still gets its own retry attempt.
+        hasRetriedLoginRedirect = false
 
         // Re-save the window's restorable state after every navigation so a relaunch reopens the page now shown,
         // not the one the window started on. `WebWindow.encodeRestorableState(with:)` reads the current URL.

--- a/Cirruscope/Web/WebViewController.swift
+++ b/Cirruscope/Web/WebViewController.swift
@@ -90,6 +90,11 @@ class WebViewController: NSViewController, WKScriptMessageHandler {
     /// `startInitialLoadIfNeeded()` seeds it with the initial target, `handleNavigationFailure(_:)` updates it to the URL that actually failed, and `retryLoad(_:)` reloads it — rather than calling `WKWebView.reload()`, which does nothing after a provisional failure that never committed a page.
     private var pendingRetryURL: URL?
 
+    /// `hasRetriedLoginRedirect` is `true` once `WebViewController+WKNavigationDelegate` has silently re-issued a navigation redirected to the server's login page with the stored app password, so a second such redirect is recognized as the credential itself being rejected rather than an ordinary expired browser-session cookie.
+    ///
+    /// `webView(_:decidePolicyFor:decisionHandler:)` sets it before retrying and consults it to decide whether to retry again or fall back to `AppDelegate.requireSignIn()`; `webView(_:didFinish:)` clears it on every successful load so a later, unrelated session expiry still gets its own retry attempt.
+    var hasRetriedLoginRedirect = false
+
     /// `webWindowController` is the `WebWindowController` hosting this controller, from which the `targetURL` to load is read once the view is in its window.
     private var webWindowController: WebWindowController? {
         view.window?.windowController as? WebWindowController
@@ -123,7 +128,8 @@ class WebViewController: NSViewController, WKScriptMessageHandler {
     /// `authenticatedRequest(for:)` builds the request that loads `url`, attaching HTTP Basic authentication derived from the `Credentials` stored for the connected server address when they are available.
     ///
     /// Nextcloud accepts the app password as Basic authentication and establishes a web session from it, so the embedded web view is signed in without a separate in-page login. When no credentials are stored the request is unauthenticated and the server presents its normal login page.
-    private func authenticatedRequest(for url: URL) -> URLRequest {
+    /// Not `private`: `WebViewController+WKNavigationDelegate` also calls this, to silently retry with the stored app password when the web view is redirected to the login page mid-session rather than at the initial load.
+    func authenticatedRequest(for url: URL) -> URLRequest {
         var request = URLRequest(url: url)
 
         if let serverAddress = AccountStore.shared.serverAddress, let credentials = Keychain.credentials(for: serverAddress) {


### PR DESCRIPTION
Under some conditions the cookies of the web view have expired and caused a redirect to the login page which was misinterpreted as an authentication failure ultimately logging the app out.

Now, in case of a redirect to the login page, a re-authentication with the stored credentials is tried first before either the session is renewed or them proven invalid indeed.

## Checklist

- [x] Every commit is signed off (`git commit -s`) per the [DCO](./CONTRIBUTING.md#developer-certificate-of-origin)
- [x] AI tools have been used in the process of creating this contribution (see [CONTRIBUTING.md](./CONTRIBUTING.md#ai-assisted-contributions))
- [x] `swiftformat .` run
- [x] `reuse lint` passes
